### PR TITLE
feat: Retain json property order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,6 +1317,7 @@ version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43535db9747a4ba938c0ce0a98cc631a46ebf943c9e1d604e091df6007620bf6"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ color-eyre = "0.5.10"
 console = "0.13.0"
 dialoguer = "0.7.1"
 toml = "0.5.8"
-serde_json = "1.0.63"
+serde_json = { version = "1.0.63", features = ["preserve_order"] }
 git2 = "0.13.17"
 regex = "1.4.3"
 semver = "0.11.0"

--- a/src/package_json.rs
+++ b/src/package_json.rs
@@ -72,7 +72,7 @@ mod tests {
     }
 
     #[test]
-    fn test_retain_property_order() {
+    fn retain_property_order() {
         let file = NamedTempFile::new().unwrap();
         let content = r###"{
         "name": "tester",

--- a/src/package_json.rs
+++ b/src/package_json.rs
@@ -70,4 +70,25 @@ mod tests {
             .to_string();
         assert_eq!(std::fs::read_to_string(file).unwrap(), expected);
     }
+
+    #[test]
+    fn test_retain_property_order() {
+        let file = NamedTempFile::new().unwrap();
+        let content = r###"{
+        "name": "tester",
+        "version": "0.1.0-rc.0",
+        "dependencies": {}
+        }"###;
+        std::fs::write(&file, content).unwrap();
+
+        set_version(&file, "1.2.3-rc.4").unwrap();
+
+        let expected = r###"{
+  "name": "tester",
+  "version": "1.2.3-rc.4",
+  "dependencies": {}
+}"###
+            .to_string();
+        assert_eq!(std::fs::read_to_string(file).unwrap(), expected);
+    }
 }


### PR DESCRIPTION
This PR retains the order of properties in a JSON file.

Currently, Dobby will alphabetize JSON properties, which means updating a `package.json` version will result in the package and version being placed below a long list of dependencies and dev-dependencies.

Workflows without a clean way to handle develop and release branches can run into issues when the standard/default order of `package.json` properties is rearranged in a single branch.