### PR TITLE
refactor(deps): Remove dependency on regex (closes #77)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,6 @@ dependencies = [
  "http",
  "markdown",
  "platform-dirs",
- "regex",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ dialoguer = "0.7.1"
 toml = "0.5.8"
 serde_json = { version = "1.0.64", features = ["preserve_order"] }
 git2 = "0.13.17"
-regex = "1.4.3"
 semver = "0.11.0"
 toml_edit = "0.2.0"
 execute = "0.2.8"

--- a/src/git.rs
+++ b/src/git.rs
@@ -91,7 +91,7 @@ pub(crate) fn select_issue_from_current_branch(state: State) -> Result<State> {
 }
 
 fn select_issue_from_branch_name(data: Initial, ref_name: &str) -> Result<IssueSelected> {
-    let parts: Vec<&str> = ref_name.split("-").collect();
+    let parts: Vec<&str> = ref_name.split('-').collect();
 
     let (key, summary) = if !parts.is_empty() && usize::from_str(parts[0]).is_ok() {
         // GitHub style, like 42-some-description for issue #42
@@ -100,7 +100,9 @@ fn select_issue_from_branch_name(data: Initial, ref_name: &str) -> Result<IssueS
         // Jira style, like PROJ-123-something-else where PROJ-123 is the issue key
         Ok((parts[0..2].join("-"), parts[2..].join("-")))
     } else {
-        Err(eyre!("Branch is not formatted properly. Was it created by Dobby?"))
+        Err(eyre!(
+            "Branch is not formatted properly. Was it created by Dobby?"
+        ))
     }?;
 
     println!("Auto-selecting issue {} from ref {}", &key, ref_name);


### PR DESCRIPTION
Please let me know if there's a better series of string methods I could use to do this more clearly. This works though and gets rid of one of our biggest dependencies!

---

After removing this and trying to check the changes to dependencies, I realized that `console` and `markdown` which we depend on both depend on regex. So there's probably no point in making this change 😢. I'll leave it up to you guys if you think this is better or worse than the original.

