### PR TITLE
refactor(deps): Remove dependency on toml_edit (closes #78)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,6 @@ dependencies = [
  "http",
  "markdown",
  "platform-dirs",
- "regex",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,12 +31,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "ascii"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
-
-[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,12 +81,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
-name = "byteorder"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
-
-[[package]]
 name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,19 +106,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "time",
- "winapi",
-]
 
 [[package]]
 name = "chunked_transfer"
@@ -163,19 +138,6 @@ dependencies = [
  "owo-colors",
  "tracing-core",
  "tracing-error",
-]
-
-[[package]]
-name = "combine"
-version = "3.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
-dependencies = [
- "ascii",
- "byteorder",
- "either",
- "memchr",
- "unreachable",
 ]
 
 [[package]]
@@ -246,7 +208,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "toml",
- "toml_edit",
  "ureq",
 ]
 
@@ -255,12 +216,6 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
-name = "either"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encode_unicode"
@@ -524,12 +479,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
-
-[[package]]
 name = "log"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,25 +530,6 @@ dependencies = [
  "lexical-core",
  "memchr",
  "version_check",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -969,16 +899,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,17 +920,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09391a441b373597cf0888d2b052dcf82c5be4fee05da3636ae30fb57aad8484"
-dependencies = [
- "chrono",
- "combine",
- "linked-hash-map",
 ]
 
 [[package]]
@@ -1118,15 +1027,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-dependencies = [
- "void",
-]
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,12 +1073,6 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ dialoguer = "0.7.1"
 toml = "0.5.8"
 serde_json = { version = "1.0.64", features = ["preserve_order"] }
 git2 = "0.13.17"
-regex = "1.4.3"
 semver = "0.11.0"
 toml_edit = "0.2.0"
 execute = "0.2.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ toml = "0.5.8"
 serde_json = { version = "1.0.64", features = ["preserve_order"] }
 git2 = "0.13.17"
 semver = "0.11.0"
-toml_edit = "0.2.0"
 execute = "0.2.8"
 platform-dirs = "0.3.0"
 git-conventional = "0.9.1"

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -16,9 +16,9 @@ pub(crate) fn get_version<P: AsRef<Path>>(path: P) -> Option<String> {
 pub(crate) fn set_version<P: AsRef<Path>>(path: P, new_version: String) -> Result<()> {
     let mut toml: toml::Value = toml::from_str(&std::fs::read_to_string(&path)?)?;
     toml.get_mut("package")
-        .ok_or(eyre!("TOML missing package key"))?
+        .ok_or_else(|| eyre!("TOML missing package key"))?
         .as_table_mut()
-        .ok_or(eyre!("TOML package key was not a table"))?
+        .ok_or_else(|| eyre!("TOML package key was not a table"))?
         .insert("version".to_string(), toml::Value::String(new_version));
     std::fs::write(path, toml::to_string_pretty(&toml)?)?;
     Ok(())

--- a/src/pyproject.rs
+++ b/src/pyproject.rs
@@ -17,11 +17,11 @@ pub(crate) fn get_version<P: AsRef<Path>>(path: P) -> Option<String> {
 pub(crate) fn set_version<P: AsRef<Path>>(path: P, new_version: String) -> Result<()> {
     let mut toml: toml::Value = toml::from_str(&std::fs::read_to_string(&path)?)?;
     toml.get_mut("tool")
-        .ok_or(eyre!("TOML missing tool key"))?
+        .ok_or_else(|| eyre!("TOML missing tool key"))?
         .get_mut("poetry")
-        .ok_or(eyre!("TOML tool table missing poetry key"))?
+        .ok_or_else(|| eyre!("TOML tool table missing poetry key"))?
         .as_table_mut()
-        .ok_or(eyre!("TOML tool.poetry key was not a table"))?
+        .ok_or_else(|| eyre!("TOML tool.poetry key was not a table"))?
         .insert("version".to_string(), toml::Value::String(new_version));
     std::fs::write(path, toml::to_string_pretty(&toml)?)?;
     Ok(())

--- a/src/pyproject.rs
+++ b/src/pyproject.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
+use color_eyre::eyre::eyre;
 use color_eyre::Result;
 use serde::Deserialize;
-use toml_edit::{value, Document};
 
 pub(crate) fn get_version<P: AsRef<Path>>(path: P) -> Option<String> {
     Some(
@@ -14,11 +14,16 @@ pub(crate) fn get_version<P: AsRef<Path>>(path: P) -> Option<String> {
     )
 }
 
-pub(crate) fn set_version<P: AsRef<Path>>(path: P, new_version: &str) -> Result<()> {
-    let toml = std::fs::read_to_string(&path)?;
-    let mut doc = toml.parse::<Document>()?;
-    doc["tool"]["poetry"]["version"] = value(new_version);
-    std::fs::write(path, doc.to_string())?;
+pub(crate) fn set_version<P: AsRef<Path>>(path: P, new_version: String) -> Result<()> {
+    let mut toml: toml::Value = toml::from_str(&std::fs::read_to_string(&path)?)?;
+    toml.get_mut("tool")
+        .ok_or(eyre!("TOML missing tool key"))?
+        .get_mut("poetry")
+        .ok_or(eyre!("TOML tool table missing poetry key"))?
+        .as_table_mut()
+        .ok_or(eyre!("TOML tool.poetry key was not a table"))?
+        .insert("version".to_string(), toml::Value::String(new_version));
+    std::fs::write(path, toml::to_string_pretty(&toml)?)?;
     Ok(())
 }
 
@@ -66,13 +71,12 @@ mod tests {
         "###;
         std::fs::write(&file, content).unwrap();
 
-        set_version(&file, "1.2.3-rc.4").unwrap();
+        set_version(&file, "1.2.3-rc.4".to_string()).unwrap();
 
-        let expected = r###"
-        [tool.poetry]
-        name = "tester"
-        version = "1.2.3-rc.4"
-        "###
+        let expected = r###"[tool.poetry]
+name = 'tester'
+version = '1.2.3-rc.4'
+"###
         .to_string();
         assert_eq!(std::fs::read_to_string(file).unwrap(), expected);
     }

--- a/src/semver.rs
+++ b/src/semver.rs
@@ -114,10 +114,10 @@ pub(crate) fn get_version() -> Result<Version> {
 
 fn set_version(version: Version) -> Result<()> {
     match version {
-        Version::Cargo(version) => crate::cargo::set_version("Cargo.toml", &version.to_string())
+        Version::Cargo(version) => crate::cargo::set_version("Cargo.toml", version.to_string())
             .wrap_err("While bumping Cargo.toml"),
         Version::PyProject(version) => {
-            pyproject::set_version("pyproject.toml", &version.to_string())
+            pyproject::set_version("pyproject.toml", version.to_string())
                 .wrap_err("While bumping pyproject.toml")
         }
         Version::Package(version) => {


### PR DESCRIPTION
Based on #77 so that needs to get merged first (avoiding cargo conflicts). We miss out on the benefits in toml_edit of retaining white space and formatting, so maybe this isn't worth it? But toml_edit is one of our biggest dependencies right now.

### Stats

| Stat | Before | After |
| ---- | ------ | ------ |
| # Deps | 186 | 170 |
| Release Build Time | 2m 11s | 1m 45s |
| Release Bin Size | 6.4 MB | 5.9 MB | 